### PR TITLE
Implement autopilot PP

### DIFF
--- a/src/mods.rs
+++ b/src/mods.rs
@@ -20,6 +20,7 @@ pub trait Mods: Copy {
     const HT: u32 = 1 << 8;
     const FL: u32 = 1 << 10;
     const SO: u32 = 1 << 12;
+    const AP: u32 = 1 << 13;
 
     /// If the clock rate is affected by the mods.
     fn change_speed(self) -> bool;
@@ -39,6 +40,7 @@ pub trait Mods: Copy {
     fn ht(self) -> bool;
     fn fl(self) -> bool;
     fn so(self) -> bool;
+    fn ap(self) -> bool;
 }
 
 impl Mods for u32 {
@@ -84,4 +86,5 @@ impl Mods for u32 {
     impl_mods!(ht, HT);
     impl_mods!(fl, FL);
     impl_mods!(so, SO);
+    impl_mods!(ap, AP);
 }

--- a/src/osu/mod.rs
+++ b/src/osu/mod.rs
@@ -149,6 +149,11 @@ impl<'map> OsuStars<'map> {
             flashlight_rating *= 0.7;
         }
 
+        if mods.ap() {
+            aim_rating = 0.0;
+            flashlight_rating *= 0.4;
+        }
+
         let base_aim_performance = (5.0 * (aim_rating / 0.0675).max(1.0) - 4.0).powi(3) / 100_000.0;
         let base_speed_performance =
             (5.0 * (speed_rating / 0.0675).max(1.0) - 4.0).powi(3) / 100_000.0;

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -546,7 +546,9 @@ impl OsuPpInner {
 
         speed_value *= self.get_combo_scaling_factor();
 
-        let ar_factor = if self.attrs.ar > 10.33 {
+        let ar_factor = if self.mods.ap() {
+            0.0
+        } else if self.attrs.ar > 10.33 {
             0.3 * (self.attrs.ar - 10.33)
         } else {
             0.0

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -456,6 +456,10 @@ impl OsuPpInner {
     }
 
     fn compute_aim_value(&self) -> f64 {
+        if self.mods.ap() {
+            return 0.0;
+        }
+
         let mut aim_value = (5.0 * (self.attrs.aim / 0.0675).max(1.0) - 4.0).powi(3) / 100_000.0;
 
         let total_hits = self.total_hits();

--- a/src/osu/skills/mod.rs
+++ b/src/osu/skills/mod.rs
@@ -31,7 +31,7 @@ impl Skills {
         Self {
             aim: Aim::new(true),
             aim_no_sliders: Aim::new(false),
-            speed: Speed::new(hit_window),
+            speed: Speed::new(hit_window, mods),
             flashlight: Flashlight::new(mods, radius, time_preempt, time_fade_in),
         }
     }

--- a/src/osu/skills/speed.rs
+++ b/src/osu/skills/speed.rs
@@ -13,13 +13,14 @@ pub(crate) struct Speed {
     pub(crate) strain_peaks: Vec<f64>,
     object_strains: Vec<f64>,
     hit_window: f64,
+    mods: u32,
 }
 
 impl Speed {
     const SKILL_MULTIPLIER: f64 = 1375.0;
     const STRAIN_DECAY_BASE: f64 = 0.3;
 
-    pub(crate) fn new(hit_window: f64) -> Self {
+    pub(crate) fn new(hit_window: f64, mods: u32) -> Self {
         Self {
             curr_strain: 0.0,
             curr_section_peak: 0.0,
@@ -28,6 +29,7 @@ impl Speed {
             strain_peaks: Vec::new(),
             object_strains: Vec::new(),
             hit_window,
+            mods,
         }
     }
 


### PR DESCRIPTION
This change implements an autopilot pp system for akatsuki-pp-rs, and acts as a rework from the currently deployed system.

This rework will:

- Remove aim difficulty & PP
- Reduce flashlight difficulty
- Remove distance calculations from speed difficulty
- Remove AR bonuses from speed PP

This PR can be merged once we are ready for deploy.