### PR TITLE
Half high AR bonus

### DIFF
--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -314,7 +314,7 @@ impl<'m> OsuPP<'m> {
 
         // AR bonus
         let mut ar_factor = if attributes.ar > 10.33 {
-            0.3 * (attributes.ar - 10.33)
+            0.15 * (attributes.ar - 10.33)
         } else {
             0.0
         };
@@ -368,7 +368,7 @@ impl<'m> OsuPP<'m> {
         // AR bonus
         if attributes.ar > 10.33 {
             let mut ar_factor = if attributes.ar > 10.33 {
-                0.3 * (attributes.ar - 10.33)
+                0.15 * (attributes.ar - 10.33)
             } else {
                 0.0
             };


### PR DESCRIPTION
Probably the easiest way to implement a change that would indirectly benefit high-BPM relax nomod maps that are very dense