### PR TITLE
change accuracy scaling, nerf length bonus, improved miss penalty, and removing high ar bonus

### DIFF
--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -314,7 +314,7 @@ impl<'m> OsuPP<'m> {
 
         // AR bonus
         let mut ar_factor = if attributes.ar > 10.33 {
-            0.3 * (attributes.ar - 10.33)
+            0.05 * (attributes.ar - 10.33)
         } else {
             0.0
         };
@@ -341,7 +341,7 @@ impl<'m> OsuPP<'m> {
         }
 
         // Scale with accuracy
-        aim_value *= 0.3 + self.acc.unwrap() / 2.0;
+        aim_value *= self.acc.unwrap() * 0.8;
         aim_value *= 0.98 + attributes.od as f32 * attributes.od as f32 / 2500.0;
 
         aim_value
@@ -368,7 +368,7 @@ impl<'m> OsuPP<'m> {
         // AR bonus
         if attributes.ar > 10.33 {
             let mut ar_factor = if attributes.ar > 10.33 {
-                0.3 * (attributes.ar - 10.33)
+                0.05 * (attributes.ar - 10.33)
             } else {
                 0.0
             };

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -310,7 +310,7 @@ impl<'m> OsuPP<'m> {
         if effective_miss_count > 0.0 {
             let miss_penalty = self.calculate_miss_penalty(
                 effective_miss_count,
-                attributes.aim_difficult_strain_count as f32,,
+                attributes.aim_difficult_strain_count as f32,
             );
             aim_value *= miss_penalty;
         }

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -344,7 +344,7 @@ impl<'m> OsuPP<'m> {
         }
 
         // Scale with accuracy
-        aim_value *= self.acc.unwrap() * 0.8;
+        aim_value *= self.acc.unwrap() / 1.25;
         aim_value *= 0.98 + attributes.od as f32 * attributes.od as f32 / 2500.0;
 
         aim_value

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -308,7 +308,10 @@ impl<'m> OsuPP<'m> {
 
         // Penalize misses
         if effective_miss_count > 0.0 {
-            let miss_penalty = self.calculate_miss_penalty(effective_miss_count);
+            let miss_penalty = self.calculate_miss_penalty(
+                effective_miss_count,
+                attributes.aim_difficult_strain_count,
+            );
             aim_value *= miss_penalty;
         }
 
@@ -361,7 +364,10 @@ impl<'m> OsuPP<'m> {
 
         // Penalize misses
         if effective_miss_count > 0.0 {
-            let miss_penalty = self.calculate_miss_penalty(effective_miss_count);
+            let miss_penalty = self.calculate_miss_penalty(
+                effective_miss_count,
+                attributes.speed_difficult_strain_count,
+            );
             speed_value *= miss_penalty;
         }
 
@@ -439,11 +445,12 @@ impl<'m> OsuPP<'m> {
     }
 
     #[inline]
-    fn calculate_miss_penalty(&self, effective_miss_count: f32) -> f32 {
-        let total_hits = self.total_hits() as f32;
-
-        0.97 * (1.0 - (effective_miss_count / total_hits).powf(0.5))
-            .powf(1.0 + (effective_miss_count / 1.5))
+    fn calculate_miss_penalty(
+        &self,
+        effective_miss_count: f32,
+        difficult_strain_count: f32,
+    ) -> f32 {
+        0.96 / ((effective_miss_count / (4.0 * difficult_strain_count.ln().powf(0.94))) + 1.0)
     }
 
     #[inline]

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -310,7 +310,7 @@ impl<'m> OsuPP<'m> {
         if effective_miss_count > 0.0 {
             let miss_penalty = self.calculate_miss_penalty(
                 effective_miss_count,
-                attributes.aim_difficult_strain_count,
+                attributes.aim_difficult_strain_count as f32,,
             );
             aim_value *= miss_penalty;
         }
@@ -366,7 +366,7 @@ impl<'m> OsuPP<'m> {
         if effective_miss_count > 0.0 {
             let miss_penalty = self.calculate_miss_penalty(
                 effective_miss_count,
-                attributes.speed_difficult_strain_count,
+                attributes.speed_difficult_strain_count as f32,
             );
             speed_value *= miss_penalty;
         }

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -303,7 +303,7 @@ impl<'m> OsuPP<'m> {
         // Longer maps are worth more
         let len_bonus = 0.88
             + 0.4 * (total_hits / 2000.0).min(1.0)
-            + (total_hits > 2000.0) as u8 as f32 * 0.5 * (total_hits / 2000.0).log10();
+            + (total_hits > 2000.0) as u8 as f32 * 0.3 * (total_hits / 2000.0).log10();
         aim_value *= len_bonus;
 
         // Penalize misses
@@ -316,15 +316,11 @@ impl<'m> OsuPP<'m> {
         }
 
         // AR bonus
-        let mut ar_factor = if attributes.ar > 10.33 {
-            0.05 * (attributes.ar - 10.33)
+        let mut ar_factor = if attributes.ar < 8.0 {
+            0.025 * (8.0 - attributes.ar)
         } else {
             0.0
         };
-
-        if attributes.ar < 8.0 {
-            ar_factor = 0.025 * (8.0 - attributes.ar);
-        }
 
         aim_value *= 1.0 + ar_factor as f32 * len_bonus;
 
@@ -359,7 +355,7 @@ impl<'m> OsuPP<'m> {
         // Longer maps are worth more
         let len_bonus = 0.88
             + 0.4 * (total_hits / 2000.0).min(1.0)
-            + (total_hits > 2000.0) as u8 as f32 * 0.5 * (total_hits / 2000.0).log10();
+            + (total_hits > 2000.0) as u8 as f32 * 0.1 * (total_hits / 2000.0).log10();
         speed_value *= len_bonus;
 
         // Penalize misses
@@ -369,21 +365,6 @@ impl<'m> OsuPP<'m> {
                 attributes.speed_difficult_strain_count as f32,
             );
             speed_value *= miss_penalty;
-        }
-
-        // AR bonus
-        if attributes.ar > 10.33 {
-            let mut ar_factor = if attributes.ar > 10.33 {
-                0.05 * (attributes.ar - 10.33)
-            } else {
-                0.0
-            };
-
-            if attributes.ar < 8.0 {
-                ar_factor = 0.025 * (8.0 - attributes.ar);
-            }
-
-            speed_value *= 1.0 + ar_factor as f32 * len_bonus;
         }
 
         // HD bonus

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -431,7 +431,7 @@ impl<'m> OsuPP<'m> {
         effective_miss_count: f32,
         difficult_strain_count: f32,
     ) -> f32 {
-        0.96 / ((effective_miss_count / (4.0 * difficult_strain_count.ln().powf(0.94))) + 1.0)
+        0.94 / ((effective_miss_count / (2.0 * strain_count.sqrt())) + 1.0)
     }
 
     #[inline]

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -431,7 +431,7 @@ impl<'m> OsuPP<'m> {
         effective_miss_count: f32,
         difficult_strain_count: f32,
     ) -> f32 {
-        0.94 / ((effective_miss_count / (2.0 * strain_count.sqrt())) + 1.0)
+        0.96 / ((effective_miss_count / (4.0 * difficult_strain_count.ln().powf(0.94))) + 1.0)
     }
 
     #[inline]


### PR DESCRIPTION
**accuracy scaling changes (also needed for future miss penalty changes)**
a more logical approach to accuracy scaling while not completely destroying pp by making justadice hddtrx ss 1.1k - in current, 60% plays get 75% of the accuracy pp that an ss play would get, but with this change, 75% gets 75% of ss accuracy pp

**removing high ar bonus (aka dt nerf; counteracting the non-dt/ht buff removal)**
finishing off what james would've wanted | atlas' daisensaw fc would be 2661pp instead of 2224pp if it was ar 11 instead of ar 10 (increase of **19.65%**) - high ar bonus isn't *that* difficult to warrant a bonus. maybe at lower levels but definitely not at higher levels, and i'd rather have a 300pp play be 260pp than a 2600pp play be 4400pp

**improved miss penalty** (edited to add this; figured this would be a good batch change)
self explanatory, the initial knee-jerk reaction to the original miss penalty being way too lenient ended up making it way too harsh. i think a pretty good example of this is how a 3 mod ss 12 miss on dai sen saw is 1k pp even though it's over 10k for fc (i don't actually know if i implemented this change correctly i just copy and pasted what james did for improved miss penalty rework)

**length bonus nerf**
a side effect of miss penalty changes is that "long" maps with 10 misses are viable, which means maps can be given a 1 minute diffspike and 10 minutes of nothing too difficult to follow so pp is artificially inflated. this *should* make longer maps more balanced without making them completely worthless. besides, sometimes they can be interesting :)