### PR TITLE
fix: passed objects getting thrown out

### DIFF
--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -131,7 +131,7 @@ impl<'m> OsuPP<'m> {
 
     #[inline]
     pub fn passed_objects(mut self, passed_objects: u32) -> Self {
-        self.passed_objects.replace(passed_objects);
+        self.passed_objects = Some(passed_objects);
 
         self
     }

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -131,7 +131,7 @@ impl<'m> OsuPP<'m> {
 
     #[inline]
     pub fn passed_objects(mut self, passed_objects: u32) -> Self {
-        self.passed_objects = self.passed_objects.replace(passed_objects);
+        self.passed_objects.replace(passed_objects);
 
         self
     }


### PR DESCRIPTION
.replace(...) returns the old value (or Some) causing the actual value to get thrown out