### PR TITLE
FL pp nerf

### DIFF
--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -333,11 +333,11 @@ impl<'m> OsuPP<'m> {
         // FL bonus
         if self.mods.fl() {
             aim_value *= 1.0
-                + 0.3 * (total_hits / 200.0).min(1.0)
+                + 0.2 * (total_hits / 200.0).min(1.0)
                 + (total_hits > 200.0) as u8 as f32
-                    * 0.25
+                    * 0.15
                     * ((total_hits - 200.0) / 300.0).min(1.0)
-                + (total_hits > 500.0) as u8 as f32 * (total_hits - 500.0) / 1600.0;
+                + (total_hits > 500.0) as u8 as f32 * (total_hits - 500.0) / 2500.0;    
         }
 
         // Scale with accuracy


### PR DESCRIPTION
FL pp was being way too nice to maps with <500 objects so i have created this change.

old scaling:
200 objects 1.3x
500 objects 1.55x
1000 objects 1.86x
6000 objects 4.98x

https://www.desmos.com/calculator/omkajskbzf

new scaling:
200 objects 1.2x
500 objects 1.35x
1000 objects 1.55x
6000 objects 3.55x

https://www.desmos.com/calculator/1au880mudt